### PR TITLE
Refine dark mode and refresh color scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
     <script>
       (function () {
         const stored = localStorage.getItem("theme");
-        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const prefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)",
+        ).matches;
         const dark = stored ? stored === "dark" : prefersDark;
         const root = document.documentElement;
         root.classList.toggle("dark", dark);
@@ -49,9 +51,9 @@
     <style>
       :root {
         /* These are overridden by site.yaml values */
-        --accent: #7c3aed; /* default violet */
-        --accent-2: #22d3ee; /* default cyan */
-        --ring: rgba(124, 58, 237, 0.35);
+        --accent: #22c55e; /* default green */
+        --accent-2: #9333ea; /* default purple */
+        --ring: rgba(34, 197, 94, 0.35);
         --bg: #0b0f19; /* default dark bg for gradient */
         --card: rgba(255, 255, 255, 0.06);
         --card-border: rgba(255, 255, 255, 0.12);
@@ -120,7 +122,7 @@
     </style>
   </head>
   <body
-    class="min-h-screen bg-orb text-slate-100 transition-colors duration-300 selection:bg-violet-500/40 selection:text-white"
+    class="min-h-screen bg-orb text-slate-900 dark:text-slate-100 transition-colors duration-300 selection:bg-green-500/40 selection:text-white"
   >
     <main class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-14">
       <!-- Header -->
@@ -135,7 +137,10 @@
             >
               Tom's Teacher Tools
             </h1>
-            <p id="site-description" class="mt-2 text-slate-300 max-w-2xl">
+            <p
+              id="site-description"
+              class="mt-2 text-slate-600 dark:text-slate-300 max-w-2xl"
+            >
               A beautiful, adaptive launcher for my apps.
             </p>
           </div>
@@ -177,7 +182,7 @@
       ></section>
 
       <!-- Footer / Last updated -->
-      <footer class="mt-12 text-sm text-slate-400">
+      <footer class="mt-12 text-sm text-slate-500 dark:text-slate-400">
         <div id="last-updated"></div>
         <div class="mt-2">
           <a href="site.yaml" class="underline hover:no-underline"
@@ -272,7 +277,7 @@ links:
         row.innerHTML = "";
         if (tags.length === 0) return;
         const label = document.createElement("span");
-        label.className = "text-slate-300 mr-1 self-center";
+        label.className = "text-slate-600 dark:text-slate-300 mr-1 self-center";
         label.textContent = "Filter:";
         row.appendChild(label);
         tags.forEach((t) => row.appendChild(createTagPill(t, false)));
@@ -392,7 +397,10 @@ links:
         btn.addEventListener("click", () => {
           const dark = !document.documentElement.classList.contains("dark");
           document.documentElement.classList.toggle("dark", dark);
-          document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
+          document.documentElement.setAttribute(
+            "data-theme",
+            dark ? "dark" : "light",
+          );
           localStorage.setItem("theme", dark ? "dark" : "light");
           updateIcon();
         });

--- a/site.yaml
+++ b/site.yaml
@@ -2,8 +2,8 @@ site:
   title: "Tom's Teacher Tools"
   description: "A beautiful, adaptive launcher for my teaching apps."
   theme:
-    accent: "#7c3aed" # violet
-    accent2: "#22d3ee" # cyan
+    accent: "#22c55e" # green
+    accent2: "#9333ea" # purple
 links:
   - title: "Sentence Builder Tool"
     url: "https://sentencebuilderapp.netlify.app/"


### PR DESCRIPTION
## Summary
- Update default accent colors to a green/purple palette
- Improve text visibility across themes and update selection color
- Ensure filter label and footer adapt to light and dark modes

## Testing
- `npx prettier --check index.html site.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68b43b8d4518832285b65129439613b0