### PR TITLE
Add Calendar Table tool link

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -20,3 +20,8 @@ links:
     description: "Generate timetables the easy way."
     icon: "📅"
     tags: ["scheduling", "school"]
+  - title: "Calendar Table Tool"
+    url: "https://calendartable.netlify.app/"
+    description: "Turn ICS files into tables."
+    icon: "📆"
+    tags: ["calendar"]


### PR DESCRIPTION
## Summary
- add Calendar Table tool for converting ICS files into tables

## Testing
- `python -c "import yaml, sys; yaml.safe_load(open('site.yaml')); print('YAML OK')"` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68ba867ffd90832284b4f9905688080c