### PR TITLE
Update Rubric Grid link

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@ links:
     icon: "🧩"
     tags: ["literacy","builder"]
   - title: "Rubric Grid Assessment"
-    url: "https://rubricgrid.netlify.app/"
+    url: "https://rubricgrid.com/"
     description: "Create & share assessment rubrics."
     icon: "✅"
     tags: ["assessment"]

--- a/site.yaml
+++ b/site.yaml
@@ -11,7 +11,7 @@ links:
     icon: "🧩"
     tags: ["literacy", "builder"]
   - title: "Rubric Grid Assessment"
-    url: "https://rubricgrid.netlify.app/"
+    url: "https://rubricgrid.com/"
     description: "Create & share assessment rubrics."
     icon: "✅"
     tags: ["assessment"]


### PR DESCRIPTION
## Summary
- update the Rubric Grid Assessment link to point at the new rubricgrid.com domain
- refresh the fallback YAML data to match the canonical link

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf1b09d2248322ab66fc09157a55a7